### PR TITLE
Add availability field to item modals and dashboard

### DIFF
--- a/react-hoardnest/src/components/EditItemModal.tsx
+++ b/react-hoardnest/src/components/EditItemModal.tsx
@@ -79,6 +79,9 @@ const EditItemModal: React.FC<EditItemModalProps> = ({
   const [quantity, setQuantity] = useState(item?.quantity?.toString() || "1");
   const [imageUrl, setImageUrl] = useState(item?.imageUrl || "");
   const [prevImageUrl, setPrevImageUrl] = useState(item?.imageUrl || "");
+  const [availability, setAvailability] = useState(
+    item?.availability || "In stock"
+  );
   // Warranty state
   const [warrantyOption, setWarrantyOption] = useState(
     item?.warranty && item?.warranty !== "as-is" && item?.warranty !== ""
@@ -120,6 +123,7 @@ const EditItemModal: React.FC<EditItemModalProps> = ({
     setQuantity(item?.quantity?.toString() || "1");
     setImageUrl(item?.imageUrl || "");
     setPrevImageUrl(item?.imageUrl || "");
+    setAvailability(item?.availability || "In stock");
     // Warranty
     setWarrantyOption(
       item?.warranty && item?.warranty !== "as-is" && item?.warranty !== ""
@@ -215,6 +219,7 @@ const EditItemModal: React.FC<EditItemModalProps> = ({
       price: parseFloat(price),
       quantity: parseInt(quantity, 10),
       imageUrl,
+      availability,
       warranty:
         warrantyOption === "warranty"
           ? {
@@ -396,6 +401,19 @@ const EditItemModal: React.FC<EditItemModalProps> = ({
               label="This item is sold as-is with no warranty"
             />
           </Box>
+          <FormControl fullWidth sx={{ mb: 2 }}>
+            <InputLabel id="availability-label">Availability</InputLabel>
+            <Select
+              labelId="availability-label"
+              value={availability}
+              label="Availability"
+              onChange={(e) => setAvailability(e.target.value)}
+              required
+            >
+              <MenuItem value="In stock">In stock</MenuItem>
+              <MenuItem value="Out of stock">Out of stock</MenuItem>
+            </Select>
+          </FormControl>
           <TextField
             label="Keywords (comma separated)"
             fullWidth

--- a/react-hoardnest/src/components/UploadSellModal.tsx
+++ b/react-hoardnest/src/components/UploadSellModal.tsx
@@ -74,6 +74,7 @@ const UploadSellModal: React.FC<UploadSellModalProps> = ({ open, onClose }) => {
   const [warrantyDuration, setWarrantyDuration] = useState("");
   const [customWarrantyDuration, setCustomWarrantyDuration] = useState("");
   const [warrantyExclusions, setWarrantyExclusions] = useState("");
+  const [availability, setAvailability] = useState("In stock");
 
   useEffect(() => {
     if (!window.cloudinary) {
@@ -141,6 +142,7 @@ const UploadSellModal: React.FC<UploadSellModalProps> = ({ open, onClose }) => {
         quantity: parseInt(quantity, 10),
         imageUrl,
         createdAt: Timestamp.now(),
+        availability,
         warranty:
           warrantyOption === "warranty"
             ? {
@@ -167,6 +169,7 @@ const UploadSellModal: React.FC<UploadSellModalProps> = ({ open, onClose }) => {
       setWarrantyDuration("");
       setCustomWarrantyDuration("");
       setWarrantyExclusions("");
+      setAvailability("In stock");
       onClose();
     } catch (error) {
       console.error("Upload failed:", error);
@@ -478,6 +481,20 @@ const UploadSellModal: React.FC<UploadSellModalProps> = ({ open, onClose }) => {
               />
             </Box>
 
+            {/* Availability dropdown */}
+            <FormControl fullWidth sx={{ mb: 2 }}>
+              <InputLabel id="availability-label">Availability</InputLabel>
+              <Select
+                labelId="availability-label"
+                value={availability}
+                label="Availability"
+                onChange={(e) => setAvailability(e.target.value)}
+                required
+              >
+                <MenuItem value="In stock">In stock</MenuItem>
+                <MenuItem value="Out of stock">Out of stock</MenuItem>
+              </Select>
+            </FormControl>
             {/* Additional metadata */}
             <TextField
               label="Keywords (comma separated)"

--- a/react-hoardnest/src/dashboard/Content.tsx
+++ b/react-hoardnest/src/dashboard/Content.tsx
@@ -66,6 +66,7 @@ interface Item {
   quantity: number;
   createdAt: any;
   warranty?: string | { duration?: string; exclusions?: string };
+  availability?: string;
 }
 
 export default function Content() {
@@ -155,6 +156,8 @@ export default function Content() {
       quantity: updated.quantity,
       imageUrl: updated.imageUrl,
       warranty: updated.warranty !== undefined ? updated.warranty : "",
+      availability:
+        updated.availability !== undefined ? updated.availability : "In stock",
     });
     setEditOpen(false);
     setEditItem(null);
@@ -305,6 +308,9 @@ export default function Content() {
                     </Typography>
                     <Typography variant="body2">
                       Quantity: <b>{item.quantity}</b>
+                    </Typography>
+                    <Typography variant="body2">
+                      Availability: <b>{item.availability || "In stock"}</b>
                     </Typography>
                     {/* Warranty display */}
                     {item.warranty && item.warranty !== "" && (


### PR DESCRIPTION
Introduces an 'availability' field to both EditItemModal and UploadSellModal components, allowing users to specify if an item is 'In stock' or 'Out of stock'. Updates the Content dashboard to display and handle the new availability property for items.