### PR TITLE
Add RevenueBreakdown component and integrate in modals

### DIFF
--- a/react-hoardnest/src/components/EditItemModal.tsx
+++ b/react-hoardnest/src/components/EditItemModal.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import RevenueBreakdown from "./RevenueBreakdown";
 import {
   Dialog,
   DialogTitle,
@@ -431,6 +432,12 @@ const EditItemModal: React.FC<EditItemModalProps> = ({
             required
             inputProps={{ min: 0, step: "0.01" }}
           />
+          {/* Revenue breakdown preview for entered price */}
+          {price && !isNaN(Number(price)) && Number(price) > 0 && (
+            <Box sx={{ mt: 2 }}>
+              <RevenueBreakdown orderValue={Number(price)} />
+            </Box>
+          )}
           <TextField
             label="Quantity"
             type="number"

--- a/react-hoardnest/src/components/RevenueBreakdown.tsx
+++ b/react-hoardnest/src/components/RevenueBreakdown.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+
+interface RevenueBreakdownProps {
+  orderValue: number;
+}
+
+// Constants for commission and shipping logic
+const STORE_COMMISSION_RATE = 0.2; // 20%
+const SHIPPING_FEE = 85; // ₱85 for orders ≤ ₱624
+const SHIPPING_FEE_THRESHOLD = 625; // Orders ≥ ₱625 get commission only
+
+function calculateRevenue(orderValue: number) {
+  let shippingFee = 0;
+  let commission = 0;
+  let sellerReceives = orderValue;
+
+  if (orderValue < SHIPPING_FEE_THRESHOLD) {
+    shippingFee = SHIPPING_FEE;
+    commission = 0;
+    sellerReceives = orderValue - shippingFee;
+  } else {
+    shippingFee = 0;
+    commission = orderValue * STORE_COMMISSION_RATE;
+    sellerReceives = orderValue - commission;
+  }
+
+  return {
+    orderValue,
+    shippingFee,
+    commission,
+    sellerReceives,
+  };
+}
+
+const RevenueBreakdown: React.FC<RevenueBreakdownProps> = ({ orderValue }) => {
+  const { shippingFee, commission, sellerReceives } =
+    calculateRevenue(orderValue);
+
+  return (
+    <div className="revenue-breakdown">
+      <h4>Revenue Breakdown</h4>
+      <ul>
+        <li>Order Value: ₱{orderValue.toFixed(2)}</li>
+        {shippingFee > 0 && (
+          <li>
+            Shipping Fee: ₱{shippingFee.toFixed(2)}{" "}
+            <span>(Applied for orders ≤ ₱624)</span>
+          </li>
+        )}
+        {commission > 0 && (
+          <li>
+            Store Commission (20%): ₱{commission.toFixed(2)}{" "}
+            <span>(Applied for orders ≥ ₱625)</span>
+          </li>
+        )}
+        <li>
+          <strong>Seller Receives: ₱{sellerReceives.toFixed(2)}</strong>
+        </li>
+      </ul>
+    </div>
+  );
+};
+
+export default RevenueBreakdown;
+export { calculateRevenue };

--- a/react-hoardnest/src/components/UploadSellModal.tsx
+++ b/react-hoardnest/src/components/UploadSellModal.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import RevenueBreakdown from "./RevenueBreakdown";
 import {
   Dialog,
   DialogTitle,
@@ -319,6 +320,12 @@ const UploadSellModal: React.FC<UploadSellModalProps> = ({ open, onClose }) => {
                   inputProps={{ min: 0, step: "0.01" }}
                   sx={{ mt: 1 }}
                 />
+                {/* Revenue breakdown preview for entered price */}
+                {price && !isNaN(Number(price)) && Number(price) > 0 && (
+                  <Box sx={{ mt: 2 }}>
+                    <RevenueBreakdown orderValue={Number(price)} />
+                  </Box>
+                )}
               </Grid>
             </Grid>
           </Box>

--- a/react-hoardnest/src/dashboard/Content.tsx
+++ b/react-hoardnest/src/dashboard/Content.tsx
@@ -24,8 +24,10 @@ import {
   updateDoc,
 } from "firebase/firestore";
 import { db } from "../firebaseConfig";
+
 import EditItemModal from "../components/EditItemModal";
 import DeleteConfirmModal from "../components/DeleteConfirmModal";
+import RevenueBreakdown from "../components/RevenueBreakdown";
 
 // Warranty display helper (matches EditItemModal logic)
 function renderWarranty(warranty: Item["warranty"]) {
@@ -303,9 +305,10 @@ export default function Content() {
                       {item.description}
                     </Typography>
 
-                    <Typography variant="body2">
-                      Price: <b>₱{item.price}</b>
-                    </Typography>
+                    {/* Revenue breakdown for this item */}
+                    <Box sx={{ mt: 1 }}>
+                      <RevenueBreakdown orderValue={item.price} />
+                    </Box>
                     <Typography variant="body2">
                       Quantity: <b>{item.quantity}</b>
                     </Typography>


### PR DESCRIPTION
Introduced a new RevenueBreakdown component to display seller revenue calculations based on order value. Integrated this component into EditItemModal, UploadSellModal, and the dashboard Content view to provide real-time revenue breakdowns for item prices.